### PR TITLE
Change I2C timeout from 2ms to 100ms

### DIFF
--- a/src/AM1805.h
+++ b/src/AM1805.h
@@ -23,7 +23,7 @@
 // Device Address
 #define AM1805_I2C_ADDR             0x69
 
-#define AM1805_I2C_TIMEOUT_MS       (2)
+#define AM1805_I2C_TIMEOUT_MS       (100)
 #define AM1805_PIN_INVALID          (PIN_INVALID)
 
 // Register Address


### PR DESCRIPTION
### Problem
Some I2C transactions may be inadvertently flagged as timed out if other system threads are blocking I2C HAL execution.

### Solution
Increase 2ms timeout to 100ms.